### PR TITLE
Hide internal stuff

### DIFF
--- a/ArmaForces.ArmaServerManager.Discord.Tests/ArmaForces.ArmaServerManager.Discord.Tests.csproj
+++ b/ArmaForces.ArmaServerManager.Discord.Tests/ArmaForces.ArmaServerManager.Discord.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ArmaForces.ArmaServerManager.Discord\ArmaForces.ArmaServerManager.Discord.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ArmaForces.ArmaServerManager.Discord.Tests/VisibilityTests.cs
+++ b/ArmaForces.ArmaServerManager.Discord.Tests/VisibilityTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using ArmaForces.ArmaServerManager.Discord.Configuration;
+using ArmaForces.ArmaServerManager.Discord.Extensions;
+using ArmaForces.ArmaServerManager.Discord.Features;
+using ArmaForces.ArmaServerManager.Discord.Features.Mods;
+using ArmaForces.ArmaServerManager.Discord.Features.Server;
+using ArmaForces.ArmaServerManager.Discord.Features.Server.DTOs;
+using ArmaForces.ArmaServerManager.Discord.Features.ServerConfig;
+using FluentAssertions;
+using Xunit;
+
+namespace ArmaForces.ArmaServerManager.Discord.Tests
+{
+    public class VisibilityTests
+    {
+        [Fact]
+        public void VisibilityTests_AllTypes_OnlyExpectedArePublic()
+        {
+            var expectedPublicTypes = new List<Type>
+            {
+                typeof(IManagerConfiguration),
+                typeof(CommandServiceExtensions),
+                typeof(ServiceCollectionExtensions),
+                typeof(IModsManagerClient),
+                typeof(ModsModule),
+                typeof(IServerManagerClient),
+                typeof(ServerModule),
+                typeof(ServerStartRequest),
+                typeof(ServerStatus),
+                typeof(IConfigurationManagerClient),
+                typeof(ServerConfigModule),
+                typeof(ManagerModuleBase)
+            };
+
+            var visibleTypes = Assembly.GetAssembly(typeof(ServerModule))?.ExportedTypes;
+
+            visibleTypes.Should().BeEquivalentTo(expectedPublicTypes);
+        }
+    }
+}

--- a/ArmaForces.ArmaServerManager.Discord.sln
+++ b/ArmaForces.ArmaServerManager.Discord.sln
@@ -3,9 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30611.23
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArmaForces.ArmaServerManager.Discord.Bot", "ArmaForces.ArmaServerManager.Discord.Bot\ArmaForces.ArmaServerManager.Discord.Bot.csproj", "{D01F0D00-28D2-43E2-9C72-9D4939F21928}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArmaForces.ArmaServerManager.Discord.Bot", "ArmaForces.ArmaServerManager.Discord.Bot\ArmaForces.ArmaServerManager.Discord.Bot.csproj", "{D01F0D00-28D2-43E2-9C72-9D4939F21928}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArmaForces.ArmaServerManager.Discord", "ArmaForces.ArmaServerManager.Discord\ArmaForces.ArmaServerManager.Discord.csproj", "{2D1E9EDD-2EB8-494B-9C31-C21022029261}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArmaForces.ArmaServerManager.Discord", "ArmaForces.ArmaServerManager.Discord\ArmaForces.ArmaServerManager.Discord.csproj", "{2D1E9EDD-2EB8-494B-9C31-C21022029261}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArmaForces.ArmaServerManager.Discord.Tests", "ArmaForces.ArmaServerManager.Discord.Tests\ArmaForces.ArmaServerManager.Discord.Tests.csproj", "{36F9860F-D07E-4461-B22A-70C30C1517E1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{2D1E9EDD-2EB8-494B-9C31-C21022029261}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D1E9EDD-2EB8-494B-9C31-C21022029261}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D1E9EDD-2EB8-494B-9C31-C21022029261}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36F9860F-D07E-4461-B22A-70C30C1517E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36F9860F-D07E-4461-B22A-70C30C1517E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36F9860F-D07E-4461-B22A-70C30C1517E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36F9860F-D07E-4461-B22A-70C30C1517E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ArmaForces.ArmaServerManager.Discord/Configuration/ManagerConfiguration.cs
+++ b/ArmaForces.ArmaServerManager.Discord/Configuration/ManagerConfiguration.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace ArmaForces.ArmaServerManager.Discord.Configuration
 {
-    public class ManagerConfiguration : IManagerConfiguration
+    internal class ManagerConfiguration : IManagerConfiguration
     {
         public string ServerManagerUrl { get; }
 

--- a/ArmaForces.ArmaServerManager.Discord/Features/ApiKeyAuthenticator.cs
+++ b/ArmaForces.ArmaServerManager.Discord/Features/ApiKeyAuthenticator.cs
@@ -4,7 +4,7 @@ using RestSharp.Authenticators;
 
 namespace ArmaForces.ArmaServerManager.Discord.Features
 {
-    public class ApiKeyAuthenticator : IAuthenticator
+    internal class ApiKeyAuthenticator : IAuthenticator
     {
         private readonly IManagerConfiguration _config;
         private const string HeaderField = "ApiKey";

--- a/ArmaForces.ArmaServerManager.Discord/Features/ManagerClientBase.cs
+++ b/ArmaForces.ArmaServerManager.Discord/Features/ManagerClientBase.cs
@@ -5,7 +5,7 @@ using RestSharp;
 
 namespace ArmaForces.ArmaServerManager.Discord.Features
 {
-    public abstract class ManagerClientBase
+    internal abstract class ManagerClientBase
     {
         private readonly IManagerConfiguration _configuration;
         protected IRestClient ManagerClient { get; set; }

--- a/ArmaForces.ArmaServerManager.Discord/Features/ManagerModuleBase.cs
+++ b/ArmaForces.ArmaServerManager.Discord/Features/ManagerModuleBase.cs
@@ -4,7 +4,7 @@ using Discord.Commands;
 
 namespace ArmaForces.ArmaServerManager.Discord.Features
 {
-    public class ManagerModuleBase : ModuleBase<SocketCommandContext>
+    public abstract class ManagerModuleBase : ModuleBase<SocketCommandContext>
     {
         protected async Task<IUserMessage> ReplyAsyncTruncate(string message)
         {

--- a/ArmaForces.ArmaServerManager.Discord/Features/Mods/DTOs/ModsUpdateRequest.cs
+++ b/ArmaForces.ArmaServerManager.Discord/Features/Mods/DTOs/ModsUpdateRequest.cs
@@ -2,7 +2,7 @@
 
 namespace ArmaForces.ArmaServerManager.Discord.Features.Mods.DTOs
 {
-    public class ModsUpdateRequest
+    internal class ModsUpdateRequest
     {
         public string ModsetName { get; set; }
 

--- a/ArmaForces.ArmaServerManager.Discord/Features/Server/Extensions/ServerManagerClientExtensions.cs
+++ b/ArmaForces.ArmaServerManager.Discord/Features/Server/Extensions/ServerManagerClientExtensions.cs
@@ -4,7 +4,7 @@ using CSharpFunctionalExtensions;
 
 namespace ArmaForces.ArmaServerManager.Discord.Features.Server.Extensions
 {
-    public static class ServerManagerClientExtensions
+    internal static class ServerManagerClientExtensions
     {
         public static Result RequestStartServer(
             this IServerManagerClient serverManagerClient,

--- a/ArmaForces.ArmaServerManager.Discord/Features/Server/IServerManagerClient.cs
+++ b/ArmaForces.ArmaServerManager.Discord/Features/Server/IServerManagerClient.cs
@@ -1,0 +1,12 @@
+﻿using ArmaForces.ArmaServerManager.Discord.Features.Server.DTOs;
+using CSharpFunctionalExtensions;
+
+namespace ArmaForces.ArmaServerManager.Discord.Features.Server
+{
+    public interface IServerManagerClient
+    {
+        Result<ServerStatus> GetServerStatus();
+
+        Result RequestStartServer(ServerStartRequest serverStartRequest);
+    }
+}

--- a/ArmaForces.ArmaServerManager.Discord/Features/Server/ServerManagerClient.cs
+++ b/ArmaForces.ArmaServerManager.Discord/Features/Server/ServerManagerClient.cs
@@ -5,7 +5,7 @@ using RestSharp;
 
 namespace ArmaForces.ArmaServerManager.Discord.Features.Server
 {
-    public class ServerManagerClient : ManagerClientBase, IServerManagerClient
+    internal class ServerManagerClient : ManagerClientBase, IServerManagerClient
     {
         // Port is const as Manager doesn't support multiple servers _yet_.
         private const int Port = 2302;
@@ -44,12 +44,5 @@ namespace ArmaForces.ArmaServerManager.Discord.Features.Server
                 ? Result.Success()
                 : ReturnFailureFromResponse<ServerStatus>(response);
         }
-    }
-
-    public interface IServerManagerClient
-    {
-        Result<ServerStatus> GetServerStatus();
-
-        Result RequestStartServer(ServerStartRequest serverStartRequest);
     }
 }

--- a/ArmaForces.ArmaServerManager.Discord/Features/ServerConfig/ConfigurationManagerClient.cs
+++ b/ArmaForces.ArmaServerManager.Discord/Features/ServerConfig/ConfigurationManagerClient.cs
@@ -5,7 +5,7 @@ using RestSharp;
 
 namespace ArmaForces.ArmaServerManager.Discord.Features.ServerConfig
 {
-    public class ConfigurationManagerClient : ManagerClientBase, IConfigurationManagerClient
+    internal class ConfigurationManagerClient : ManagerClientBase, IConfigurationManagerClient
     {
         private string ConfigurationApiPath { get; } = "api/configuration";
 
@@ -86,16 +86,5 @@ namespace ArmaForces.ArmaServerManager.Discord.Features.ServerConfig
                 ? Result.Success(response.Content)
                 : ReturnFailureFromResponse<string>(response);
         }
-    }
-
-    public interface IConfigurationManagerClient
-    {
-        Result<string> GetServerConfiguration();
-
-        Result<string> GetModsetConfiguration(string modsetName);
-
-        Result<string> PutServerConfiguration(string configContent);
-
-        Result<string> PutModsetConfiguration(string modsetName, string configContent);
     }
 }

--- a/ArmaForces.ArmaServerManager.Discord/Features/ServerConfig/IConfigurationManagerClient.cs
+++ b/ArmaForces.ArmaServerManager.Discord/Features/ServerConfig/IConfigurationManagerClient.cs
@@ -1,0 +1,15 @@
+﻿using CSharpFunctionalExtensions;
+
+namespace ArmaForces.ArmaServerManager.Discord.Features.ServerConfig
+{
+    public interface IConfigurationManagerClient
+    {
+        Result<string> GetServerConfiguration();
+
+        Result<string> GetModsetConfiguration(string modsetName);
+
+        Result<string> PutServerConfiguration(string configContent);
+
+        Result<string> PutModsetConfiguration(string modsetName, string configContent);
+    }
+}


### PR DESCRIPTION
When merged this PR will:
- Hide all types except:
  - IManagerConfiguration
  - CommandServiceExtensions
  - ServiceCollectionExtensions
  - IModsManagerClient
  - ModsModule
  - IServerManagerClient
  - ServerModule
  - ServerStartRequest
  - ServerStatus
  - IConfigurationManagerClient
  - ServerConfigModule
  - ManagerModuleBase
- Add test project with visibility tests